### PR TITLE
Remove lodash entirely

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "use-media-set",
       "version": "2.1.0",
       "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
       "devDependencies": {
         "@biomejs/biome": "^2.0.0",
         "@testing-library/dom": "^10.4.0",
@@ -2528,12 +2525,6 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
     },
     "node_modules/loupe": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -44,9 +44,6 @@
     "deploy": "gh-pages -d example/dist",
     "postpublish": "git push --tags"
   },
-  "dependencies": {
-    "lodash": "^4.17.21"
-  },
   "peerDependencies": {
     "react": "^18 || ^19"
   },

--- a/src/asMediaQuery.js
+++ b/src/asMediaQuery.js
@@ -1,10 +1,19 @@
-import isPlainObject from 'lodash/isPlainObject';
-import kebabCase from 'lodash/kebabCase';
-
-// Lodash's _.capitalize() won't do here, because it not only
-// capitalizes the string but lowercases the rest of it, which
-// we do not want here. This will work well enough.
+// A plain capitalize() won't do here: we only want to upper-case the first
+// letter without lower-casing the rest. This will work well enough.
 const capitalize = s => s[0].toUpperCase() + s.slice(1);
+
+// Convert a camelCase media feature name to its kebab-case CSS form,
+// e.g. 'deviceAspectRatio' -> 'device-aspect-ratio'. Feature names are
+// always simple camelCase, so a boundary regex is sufficient.
+const kebabCase = s => s.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+
+// True only for plain objects — created via an object literal or
+// Object.create(null) — and not for arrays, null, or class instances.
+const isPlainObject = v => {
+  if (v === null || typeof v !== 'object') return false;
+  const proto = Object.getPrototypeOf(v);
+  return proto === Object.prototype || proto === null;
+};
 
 const mediaTypes = Object.freeze([
   'all',

--- a/src/asMediaQuery.test.js
+++ b/src/asMediaQuery.test.js
@@ -1,4 +1,3 @@
-import kebabCase from 'lodash/kebabCase';
 import { MediaQueryError, asMediaQuery as subject } from './asMediaQuery';
 
 describe('asMediaQuery', () => {
@@ -35,10 +34,16 @@ describe('asMediaQuery', () => {
     });
 
     it('adds default px to length-style features', () => {
-      ['width', 'height', 'deviceWidth', 'deviceHeight'].forEach(n => {
-        const result = subject({ [n]: 100 });
-        expect(result).toBe(`(${kebabCase(n)}: 100px)`);
-      });
+      const cases = {
+        width: 'width',
+        height: 'height',
+        deviceWidth: 'device-width',
+        deviceHeight: 'device-height',
+      };
+      for (const [feature, css] of Object.entries(cases)) {
+        const result = subject({ [feature]: 100 });
+        expect(result).toBe(`(${css}: 100px)`);
+      }
     });
 
     it('does not add px to non-length-style features', () => {

--- a/src/debounce.js
+++ b/src/debounce.js
@@ -1,0 +1,21 @@
+// A minimal trailing-edge debounce: `fn` is invoked once, `delay` ms after
+// the most recent call. The returned function exposes a `.cancel()` that
+// drops any pending invocation (used on effect cleanup).
+export default function debounce(fn, delay) {
+  let timer;
+
+  function debounced(...args) {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = undefined;
+      fn(...args);
+    }, delay);
+  }
+
+  debounced.cancel = () => {
+    clearTimeout(timer);
+    timer = undefined;
+  };
+
+  return debounced;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
-import debounce from 'lodash/debounce';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { asMediaQuery } from './asMediaQuery';
+import debounce from './debounce';
 
 const DELAY = 50;
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -3,10 +3,10 @@ import { useMediaSet } from './';
 
 // Count how many times the debounced state setter actually fires, so we can
 // assert that rapid, near-simultaneous media changes are coalesced into a
-// single state update. We wrap the function lodash debounces (the state
+// single state update. We wrap the function our debounce receives (the state
 // setter) while preserving the real debounce behavior.
 const spy = vi.hoisted(() => ({ debouncedCalls: 0 }));
-vi.mock('lodash/debounce', async importOriginal => {
+vi.mock('./debounce', async importOriginal => {
   const debounce = (await importOriginal()).default;
   return {
     default: (fn, ...rest) =>
@@ -20,8 +20,7 @@ vi.mock('lodash/debounce', async importOriginal => {
   };
 });
 
-// advances the fake timers; Vitest's fake timers also mock Date,
-// which lodash debounce relies on to decide when to fire.
+// advances the fake timers so a pending debounced update fires.
 function advance(ms) {
   act(() => {
     vi.advanceTimersByTime(ms);

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,7 +12,7 @@ export default defineConfig({
     },
     rollupOptions: {
       // Don't bundle peer deps or declared dependencies; let consumers dedupe them.
-      external: ['react', 'react-dom', /^lodash/],
+      external: ['react', 'react-dom'],
     },
   },
   test: {


### PR DESCRIPTION
- kebabCase → native regex helper
- isPlainObject → native prototype check
- debounce → local src/debounce.js (trailing debounce with cancel)
- Drop lodash from dependencies and the Vite external list